### PR TITLE
requirements.txt: Prevent use of Django 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-django
+django<2.0
 django-distill
 IGitt


### PR DESCRIPTION
It is incompatible with django-distill at the moment.

Fixes https://github.com/coala/community/issues/19