### PR TITLE
.coafile: Ignore public/**

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -40,7 +40,7 @@ shell = bash
 # Do not allow the word "coala" to ensure the repository can be generalized out
 # for use by other organizations.
 files = **
-ignore = .git/**, org_name.txt, .coafile, requirements.txt, .travis.yml, LICENSE
+ignore = .git/**, org_name.txt, .coafile, requirements.txt, .travis.yml, LICENSE, public/**
 bears = KeywordBear
 language = python 3
 keywords = coala


### PR DESCRIPTION
The public/ rendered version contains the word coala,
and thus needs to be ignored from the KeywordBear rule.

Related to https://github.com/coala/community/issues/3