### PR TITLE
.coafile: Ignore coala in generated GCI files

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -7,6 +7,7 @@ mkdir private _site public
 if [[ -n "$GCI_TOKEN" ]]; then
   python manage.py fetch_gci_task_data private
   python manage.py cleanse_gci_task_data private _site
+  rm -rf private/
 else
   python manage.py fetch_old_gci_task_data _site || true
 fi

--- a/.coafile
+++ b/.coafile
@@ -1,6 +1,6 @@
 [all]
 files = *.py, community/**/*.py, gci/**/*.py, activity/*.py
-ignore = gci/client.py, gci/migrations/**
+ignore = gci/client.py, gci/migrations/**, private/**
 max_line_length = 80
 use_spaces = True
 
@@ -40,7 +40,7 @@ shell = bash
 # Do not allow the word "coala" to ensure the repository can be generalized out
 # for use by other organizations.
 files = **
-ignore = .git/**, org_name.txt, .coafile, requirements.txt, .travis.yml, LICENSE, public/**
+ignore = .git/**, org_name.txt, .coafile, requirements.txt, .travis.yml, LICENSE, public/**, _site/**
 bears = KeywordBear
 language = python 3
 keywords = coala

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
 
 script:
   - ./.ci/build.sh
+  - rm -rf private/
   - coala --non-interactive -V
 
 after_success:


### PR DESCRIPTION
The GCI exported data contains 'coala',
so it needs to be excluded from the relevant checks.

Also ignore private/** and delete it regularly,
as a preventative measure for accidental leaks.

Related to https://github.com/coala/community/issues/3