### PR TITLE
gci/feeds: Create RSS feed of tasks

### DIFF
--- a/community/settings.py
+++ b/community/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'v-#^6q@r4@lu*o%1$*c^7fpt8nl__*ac&oc1-of6)cwkdsp0#1'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['127.0.0.1', 'localhost', 'testserver']
 
 
 # Application definition

--- a/community/urls.py
+++ b/community/urls.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.views.generic import TemplateView
 
 from gci.views import index as gci_index
+from gci.feeds import LatestTasksFeed as gci_tasks_rss
 from activity.scraper import activity_json
 from twitter.view_twitter import index as twitter_index
 
@@ -36,6 +37,12 @@ urlpatterns = [
         name='activity',
         distill_func=get_index,
         distill_file='activity/index.html',
+    ),
+    distill_url(
+        r'gci/tasks/rss.xml', gci_tasks_rss(),
+        name='gci-tasks-rss',
+        distill_func=get_index,
+        distill_file='gci/tasks/rss.xml',
     ),
     distill_url(
         r'gci/', gci_index,

--- a/gci/feeds.py
+++ b/gci/feeds.py
@@ -1,0 +1,49 @@
+import os.path
+from ruamel.yaml import YAML
+import markdown2
+import dateutil.parser
+
+from django.contrib.syndication.views import Feed
+from community.git import get_deploy_url, get_owner
+
+
+class LatestTasksFeed(Feed):
+    title = 'GCI tasks feed'
+    link = get_deploy_url() + '/gci/tasks/rss.xml'
+    description = 'GCI tasks ordered by modification time.'
+    author_name = get_owner()
+    author_link = get_deploy_url()
+
+    def items(self):
+        yaml = YAML()
+        with open(os.path.join('_site', 'tasks.yaml')) as f:
+            res = list(yaml.load(f).values())
+
+        res.sort(key=lambda x: x['last_modified'], reverse=True)
+
+        return res
+
+    def item_title(self, item):
+        return item['name']
+
+    def item_description(self, item):
+        desc = item['description']
+        if item['external_url']:
+            desc += '\n\nExternal URL: [{url}]({url})'.format(
+                url=item['external_url'])
+        return markdown2.markdown(desc)
+
+    def item_link(self, item):
+        return 'https://codein.withgoogle.com/tasks/' + str(item['id'])
+
+    def item_pubdate(self, item):
+        return dateutil.parser.parse(item['last_modified'])
+
+    def item_updateddate(self, item):
+        return dateutil.parser.parse(item['last_modified'])
+
+    def item_author_name(self):
+        return self.author_name
+
+    def item_categories(self, item):
+        return tuple(item['tags'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ requests
 python-dateutil
 pillow
 ruamel.yaml
+markdown2
+python_dateutil


### PR DESCRIPTION
Creates RSS feed for tasks. Task descriptions are rendered HTML from markdown, along with external URL, if any. Link points to GCI task link.

Closes https://github.com/coala/community/issues/57