### PR TITLE
config.py: Use global setting instead of local

### DIFF
--- a/gci/config.py
+++ b/gci/config.py
@@ -1,11 +1,12 @@
 import ruamel.yaml
 import os
+from community.settings import STATIC_ROOT
 
 API_KEY_FILE = '.%s_API_KEY'
 
 GCI_DATA_DIR = os.path.join(
     os.path.dirname(__file__), '..',
-    '_site',
+    STATIC_ROOT,
 )
 
 


### PR DESCRIPTION
Local setting for GCI data directory variable changed to global
using global variable STATIC_ROOT in place of '_site/'

Closes https://github.com/coala/community/issues/71
