### PR TITLE
Add: Inactive Issues app

### DIFF
--- a/community/urls.py
+++ b/community/urls.py
@@ -12,6 +12,7 @@ from activity.scraper import activity_json
 from twitter.view_twitter import index as twitter_index
 from log.view_log import index as log_index
 from data.views import index as contributors_index
+from inactive_issues.inactive_issues_scraper import inactive_issues_json
 
 
 def get_index():
@@ -69,5 +70,11 @@ urlpatterns = [
         name='community-gsoc',
         distill_func=get_index,
         distill_file='contributors/index.html',
+    ),
+    distill_url(
+        r'static/inactive-issues.json', inactive_issues_json,
+        name='inactive_issues_json',
+        distill_func=get_index,
+        distill_file='static/inactive-issues.json',
     ),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/inactive_issues/inactive_issues_scraper.py
+++ b/inactive_issues/inactive_issues_scraper.py
@@ -1,0 +1,67 @@
+import time
+import json
+
+from github import Github
+from dateutil.parser import parse
+from datetime import date
+from django.http import HttpResponse
+from gci.config import get_api_key
+
+from community.git import get_owner
+
+
+def run(issues):
+    issues_number_list = []
+    for j in issues:
+        issue_no = j.number
+        events = j.get_events()
+        myevent = []
+        data = []
+        for i in events:
+            myevent.append(str(i.event))
+        for i in events:
+            if i.commit_id is not None:
+                data.append(str(i.created_at))
+        for i, myevents in reversed(list(enumerate(myevent))):
+            if myevents == 'unassigned':
+                break
+            elif myevents == 'assigned':
+                a = events[i].created_at
+                c = (date.fromtimestamp(time.time()) - a.date()).days
+                if c >= 60:  # for checking assigned duration
+
+                    mydata = list(reversed(data))
+                    if len(mydata) != 0:
+                        commit1 = parse(mydata[0])
+                        calculated_days = (date.fromtimestamp(
+                            time.time()) - commit1.date()).days
+                        if calculated_days >= 60:
+                            # for checking last commit update
+                            issues_number_list.append(issue_no)
+                    else:
+                        issues_number_list.append(issue_no)
+                break
+    return issues_number_list
+
+
+def inactive_issues_json(request):
+    try:
+        GH_TOKEN = get_api_key('GH')
+    except:
+        return HttpResponse('[]')
+    g1 = Github(GH_TOKEN)
+    org_name = get_owner()
+    org = g1.get_organization(org_name)
+    repo = org.get_repo(org_name)
+    issues = repo.get_issues()
+    issues_list = []
+    for myissue in issues:
+        label = []
+        for mylabel in myissue.labels:
+            label.append(mylabel.name)
+        if 'status/blocked' not in label:
+            if myissue.state == 'open' and myissue.pull_request is None:
+                issues_list.append(myissue)
+
+    final_list = run(issues_list)
+    return HttpResponse(json.dumps(final_list))

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pillow
 ruamel.yaml
 markdown2
 python_dateutil
+PyGithub

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,5 +7,7 @@
     <li><a href="/twitter/">Twitter Feed</a>
     <li><a href="/log/">Logs</a>
     <li><a href="/contributors/">Contributors data</a>
+    <li><a title="List of all the issues on organization&#13;&#10;main repository on which assignee&#13;&#10;has not shown any activity&#13;&#10;for more than 2 months."
+           href="/static/inactive-issues.json">Inactive Issues</a>
 </ul>
 </body>


### PR DESCRIPTION
Add inactive_issues app, currently it work
on coala/coala repo, but to work on any
other repo pass the repository owner name in
`get_organization()` and repository name in
'get_repo()` in `inactive_issues_scraper` file.