### PR TITLE
models.py: fixed openhub models str method

### DIFF
--- a/openhub/models.py
+++ b/openhub/models.py
@@ -99,7 +99,7 @@ class MostCommit(models.Model):
     commits = models.IntegerField()
 
     def __str__(self):
-        return self.project1
+        return self.project
 
 
 class MostRecentCommit(models.Model):
@@ -108,7 +108,7 @@ class MostRecentCommit(models.Model):
     date = models.CharField(max_length=100)
 
     def __str__(self):
-        return self.project2
+        return self.project
 
 
 class AffiliatedCommitter(models.Model):


### PR DESCRIPTION
This fixes the return for MostCommit and MostRecentCommit models.

Closes https://github.com/coala/community/issues/116