### PR TITLE
openhub/models.py: Fix str method

### DIFF
--- a/openhub/models.py
+++ b/openhub/models.py
@@ -99,7 +99,7 @@ class MostCommit(models.Model):
     commits = models.IntegerField()
 
     def __str__(self):
-        return self.project1
+        return self.project
 
 
 class MostRecentCommit(models.Model):
@@ -108,7 +108,7 @@ class MostRecentCommit(models.Model):
     date = models.CharField(max_length=100)
 
     def __str__(self):
-        return self.project2
+        return self.project
 
 
 class AffiliatedCommitter(models.Model):


### PR DESCRIPTION
self.project1 -> self.project for MostCommit model
self.project2 -> self.project for MostRecentCommit model

Closes https://github.com/coala/community/issues/116