### PR TITLE
.travis.yml: Restructure env keys

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -43,6 +43,11 @@ bears = JSHintBear
 allow_unused_variables = True
 javascript_strictness = False
 
+[all.yml]
+bears = YAMLLintBear
+files = **.yml, **.yaml
+ignore += public/**, _site/**
+
 [bash]
 files = **.sh
 bears = ShellCheckBear

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,15 @@ cache:
 
 env:
   global:
-  - ENCRYPTION_LABEL: "defac9b1fa56"
-  - COMMIT_AUTHOR_EMAIL: "nobody@coala.io"
-
-env:
-  # This more closely emulates a forked build
-  # However the git remote is not correct
-  # Only a GH_TOKEN is required.
-  - GL_TOKEN="" GCI_TOKEN="" OH_TOKEN=""
-  # A proper build with the tokens available
-  - AUTH=true
+    - ENCRYPTION_LABEL: "defac9b1fa56"
+    - COMMIT_AUTHOR_EMAIL: "nobody@coala.io"
+  matrix:
+    # This more closely emulates a forked build
+    # However the git remote is not correct
+    # Only a GH_TOKEN is required.
+    - GL_TOKEN="" GCI_TOKEN="" OH_TOKEN=""
+    # A proper build with the tokens available
+    - AUTH=true
 
 jobs:
   include:


### PR DESCRIPTION
The YAML had two env: keys.

Related to https://github.com/coala/community/issues/131