### PR TITLE
.gitignore: Ignore prof directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -479,3 +479,6 @@ _site/
 *.patch
 *.orig
 *.diff
+
+# Pytest profile files
+prof/


### PR DESCRIPTION
Adds `prof/` to the `.gitignore` file.

Closes https://github.com/coala/community/issues/156