### PR TITLE
gci: Fix GitHub cards failing to render

### DIFF
--- a/gci/views.py
+++ b/gci/views.py
@@ -81,8 +81,8 @@ def gci_overview():
              .format(unix=timegm(datetime.utcnow().utctimetuple()),
                      timestamp=timestamp))
 
-    s.append('<script src="//cdn.jsdelivr.net/github-cards/latest/widget.js">'
-             '</script>')
+    s.append('<script src="//cdn.jsdelivr.net/gh/lepture/github-cards@1.0.2'
+             '/jsdelivr/widget.js"></script>')
     s.append('<script src="static/timeago.js"></script>')
     s.append('<script>loadTimeElements()</script>')
 


### PR DESCRIPTION
GCI GitHub cards would display HTML instead of the actual card
element due to an issue upstream. This upgrades the github-cards
dependency to solve this problem.

Fixes https://github.com/coala/community/issues/135