### PR TITLE
data/: Fix import_contributors_data command

### DIFF
--- a/data/management/commands/import_contributors_data.py
+++ b/data/management/commands/import_contributors_data.py
@@ -10,5 +10,7 @@ class Command(BaseCommand):
     IMPORT_DATA = staticmethod(import_data)
 
     def handle(self, *args, **options):
-        for contributor in self.CONTRIBUTORS():
-            self.IMPORT_DATA(contributor)
+        CONTRIBUTORS_DATA = self.CONTRIBUTORS()
+        if CONTRIBUTORS_DATA:
+            for contributor in CONTRIBUTORS_DATA:
+                self.IMPORT_DATA(contributor)


### PR DESCRIPTION
This fix the import_contributors_data command
when the webservices has a server error and our
returned data by the method get_contrib_data is None,
then while iterating through the contributors data
in the management command we need to first check
if the data is not empty to avoid the error:
```
TypeError: 'NoneType' object is not iterable
```
Fixes https://github.com/coala/community/issues/167