### PR TITLE
Add meta-review to gamification

### DIFF
--- a/gamification/data/config.py
+++ b/gamification/data/config.py
@@ -76,6 +76,8 @@ def create_badge_activities():
             name='Solved a area/genericbears bear proposal issue'),
         BadgeActivity(
             name='Solved a area/lintbears bear proposal issue'),
+        BadgeActivity(
+            name='Did a meta-review or received a meta-review'),
     ]
     BadgeActivity.objects.bulk_create(b_activity__object_list)
 
@@ -241,9 +243,12 @@ def add_activities_to_badges():
         name='Solved a difficulty/newcomer issue')
     all_rounder_activity2 = BadgeActivity.objects.get(
         name='Solved a difficulty/low issue')
+    all_rounder_activity3 = BadgeActivity.objects.get(
+        name='Did a meta-review or received a meta-review')
     all_rounder_activities_list = [
         all_rounder_activity1,
         all_rounder_activity2,
+        all_rounder_activity3,
     ]
     all_rounder_badge.b_activities.add(
         *all_rounder_activities_list)

--- a/gamification/management/commands/update_participants_data.py
+++ b/gamification/management/commands/update_participants_data.py
@@ -9,6 +9,8 @@ from gamification.process.update import (
     update_participants_data_with_issue,
     get_participant_objects,
     award_badges,
+    get_meta_review_participant_objects,
+    update_participants_data_with_meta_review,
 )
 
 
@@ -31,3 +33,5 @@ class Command(BaseCommand):
             update_participants_data_with_issue(issue)
         for participant in get_participant_objects():
             award_badges(participant)
+        for participant in get_meta_review_participant_objects():
+            update_participants_data_with_meta_review(participant.login)

--- a/gamification/tests/test_management_commands.py
+++ b/gamification/tests/test_management_commands.py
@@ -24,10 +24,10 @@ class CreateConfigDataTest(TestCase):
         self.assertEquals(levels.count(), 8)
 
         b_activities = BadgeActivity.objects.all()
-        # There must be 26 badge activities created
-        # as there are 26 badge_activities listed in
+        # There must be 27 badge activities created
+        # as there are 27 badge_activities listed in
         # file config.py
-        self.assertEquals(b_activities.count(), 26)
+        self.assertEquals(b_activities.count(), 27)
 
         badges = Badge.objects.all()
         # There must be 8 badges created
@@ -61,7 +61,7 @@ class CreateConfigDataTest(TestCase):
 
         # The All-Rounder badge must have two activities
         badge7 = Badge.objects.get(name='The All-Rounder')
-        self.assertEquals(badge7.b_activities.count(), 2)
+        self.assertEquals(badge7.b_activities.count(), 3)
 
 
 class CreateParticipantsTest(TestCase):
@@ -97,4 +97,4 @@ class UpdateParticipantsTest(TestCase):
         self.assertEquals(current_level, 'Intermediate-II')
 
         number_of_badges = participant.badges.all().count()
-        self.assertEquals(number_of_badges, 2)
+        self.assertEquals(number_of_badges, 1)


### PR DESCRIPTION
From this PR, we add the meta-review activity on the gamification page of the active newcomers.

Closes https://github.com/coala/community/issues/181