### PR TITLE
Fix: Issue 185

### DIFF
--- a/community/git.py
+++ b/community/git.py
@@ -176,11 +176,15 @@ def get_deploy_url(name=None):
     return deploy_url
 
 
-def get_upstream_deploy_url():
-    """Obtain the http where the upstream deploys appear.
+def get_upstream_deploy_url(name=None):
+    """
+    Obtain the http where the upstream deploys appear.
+    When `name` is None, fetch current repo of current org,
+    otherwise, fetch a specified repo of current org.
     """
     repo = get_upstream_repo()
-    owner, _, path = repo.full_name.partition('/')
+    owner, _, repo_name = repo.full_name.partition('/')
+    path = name if name else repo_name
     deploy_url = 'https://%s.github.io/%s' % (owner, path)
 
     return deploy_url

--- a/data/management/commands/fetch_deployed_data.py
+++ b/data/management/commands/fetch_deployed_data.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
 
         deploy_url = get_deploy_url(repo_name)
         try:
-            upstream_deploy_url = get_upstream_deploy_url()
+            upstream_deploy_url = get_upstream_deploy_url(repo_name)
         except RuntimeError as e:
             upstream_deploy_url = None
             logger.info(str(e))


### PR DESCRIPTION
git.py : Add name argument to get_upstream_deploy_url method

When fetching the deployed data from the upstream, it tried to fetch
from the current repo even if the data is from a different repo.
Thus adding a repo name argument ensures that the data is fetched
from the repo it is actually in.

Fixes https://github.com/coala/community/issues/185