### PR TITLE
requirements.txt: Bump IGitt dependency

### DIFF
--- a/.moban.yaml
+++ b/.moban.yaml
@@ -21,7 +21,7 @@ dependencies:
   - django
   - django-distill
   - django-eventtools
-  - git+https://gitlab.com/gitmate/open-source/IGitt.git@1fa5a0a21ea4fb8739d467c06972f748717adbdc
+  - git+https://gitlab.com/jayvdb/IGitt.git@74a0141f3d77b8a51b6d964f9c64da67751e3762
   - requests
   - python-dateutil
   - pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ git-url-parse
 django
 django-distill
 django-eventtools
-git+https://gitlab.com/gitmate/open-source/IGitt.git@1fa5a0a21ea4fb8739d467c06972f748717adbdc
+git+https://gitlab.com/jayvdb/IGitt.git@74a0141f3d77b8a51b6d964f9c64da67751e3762
 requests
 python-dateutil
 pillow


### PR DESCRIPTION
Use latest IGitt, and also include a commit which
unpins package `cryptography` so it is easier to
install IGitt, otherwise the old version required of
`cryptography` may require the user has a compiler
set up, as wheels may not work on their system.