### PR TITLE
.moban.yaml: Disable openhub module

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -32,7 +32,6 @@ python manage.py import_merge_requests_data
 python manage.py create_config_data
 python manage.py create_participants
 python manage.py update_participants_data
-python manage.py import_openhub_data
 
 if [[ -f "_site/$META_REVIEW_DATA" ]]; then
   echo "File $META_REVIEW_DATA exists."

--- a/.moban.yaml
+++ b/.moban.yaml
@@ -11,7 +11,6 @@ packages:
   - gamification
   - log
   - meta_review
-  - openhub
   - model
   - twitter
   - unassigned_issues

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ testpaths =
   gamification
   log
   meta_review
-  openhub
   model
   twitter
   unassigned_issues
@@ -73,7 +72,6 @@ source =
   gamification
   log
   meta_review
-  openhub
   model
   twitter
   unassigned_issues


### PR DESCRIPTION
openhub app is broken at the moment which
is causing netlify to fail. So, this commit
disables the openhub module until we find out
the problem and fix it.