### PR TITLE
OpenHub: /openhub shows how to get OH_TOKEN if not set

### DIFF
--- a/openhub/views.py
+++ b/openhub/views.py
@@ -1,9 +1,20 @@
 from django.shortcuts import render
 
 from openhub.models import PortfolioProject
+from openhub.oh_token import OH_TOKEN
 
 
 def index(request):
-    projects = PortfolioProject.objects.all()
-    args = {'projects': projects}
+    errors = []
+    projects = []
+    if OH_TOKEN is None:
+        errors.append("""
+        OH_TOKEN is not specified as an environment variable. <br/>
+        You can get an OpenHub token by signing up at
+        <a href="https://www.openhub.net">openhub.net</a>.
+        """)
+    else:
+        projects = PortfolioProject.objects.all()
+
+    args = {'projects': projects, 'errors': errors}
     return render(request, 'openhub.html', args)

--- a/templates/openhub.html
+++ b/templates/openhub.html
@@ -10,6 +10,10 @@
   </head>
   <body>
     <h1>All of our Portfolio Projects</h1>
+    {%  for error in errors %}
+    <p>{{ error | safe }}</p>
+    {%  endfor  %}
+
     {% for project in projects %}
     <div class="container">
       <div class="row">


### PR DESCRIPTION
/openhub now shows a short message on how to get an OH_TOKEN if it's not set

Closes https://github.com/coala/community/issues/201

Unsure if having the message in the code like that is okay, but I was unable to think of another way to do it. 