### PR TITLE
manage.py: Raise min python version to 3.6

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -4,6 +4,8 @@ import sys
 
 
 if __name__ == '__main__':
+    if (sys.version_info[0], sys.version_info[1]) < (3, 6):
+        raise Exception('Minimum python version 3.6 is required.')
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'community.settings')
     try:
         from django.core.management import execute_from_command_line


### PR DESCRIPTION
Raise an Exception if python version is < 3.6

Closes https://github.com/coala/community/issues/223