### PR TITLE
views.py: Fix typo referencing wrong Travis env variable

### DIFF
--- a/.moban.yaml
+++ b/.moban.yaml
@@ -23,7 +23,7 @@ dependencies:
   - django-eventtools
   - git+https://gitlab.com/gitmate/open-source/IGitt.git@1fa5a0a21ea4fb8739d467c06972f748717adbdc
   - requests
-  - git+https://github.com/andrewda/trav.git
+  - git+https://github.com/andrewda/trav.git@ce805d12d3d1db0a51b1aa26bba9cd9ecc0d96b8
   - python-dateutil
   - pillow
   - ruamel.yaml

--- a/community/views.py
+++ b/community/views.py
@@ -17,7 +17,7 @@ class HomePageView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['isTravis'] = Travis.TRAVIS
-        context['travisLink'] = Travis.BUILD_WEB_URL
+        context['travisLink'] = Travis.TRAVIS_BUILD_WEB_URL
 
         print('Running on Travis: {}, build link: {}'.format(
             context['isTravis'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ django-distill
 django-eventtools
 git+https://gitlab.com/gitmate/open-source/IGitt.git@1fa5a0a21ea4fb8739d467c06972f748717adbdc
 requests
-git+https://github.com/andrewda/trav.git
+git+https://github.com/andrewda/trav.git@ce805d12d3d1db0a51b1aa26bba9cd9ecc0d96b8
 python-dateutil
 pillow
 ruamel.yaml


### PR DESCRIPTION
Fix typo that was causing Travis to fail on master.
Specify specific commit for trav in requirements.txt
to prevent this from happening again.

Fixes https://github.com/coala/community/issues/226