### PR TITLE
Install Django v2.1 and Sync moban

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,13 @@ ipython_config.py
 # pyenv
 .python-version
 
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
 # celery beat schedule file
 celerybeat-schedule
 
@@ -152,6 +159,7 @@ pip-selfcheck.json
 # Windows rules
 # Windows thumbnail cache files
 Thumbs.db
+Thumbs.db:encryptable
 ehthumbs.db
 ehthumbs_vista.db
 
@@ -307,6 +315,8 @@ tags
 # .idea/modules.xml
 # .idea/*.iml
 # .idea/modules
+# *.iml
+# *.ipr
 
 # CMake
 cmake-build-*/
@@ -419,8 +429,14 @@ DerivedData/
 *.perspectivev3
 !default.perspectivev3
 
-# Eclipse rules
+## Xcode Patch
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
 
+# Eclipse rules
 .metadata
 bin/
 tmp/

--- a/.moban.yaml
+++ b/.moban.yaml
@@ -18,7 +18,7 @@ packages:
 dependencies:
   - git+https://gitlab.com/coala/coala-utils.git
   - git-url-parse
-  - django
+  - django>2.1,<2.2
   - django-distill
   - django-eventtools
   - git+https://gitlab.com/gitmate/open-source/IGitt.git@1fa5a0a21ea4fb8739d467c06972f748717adbdc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://gitlab.com/coala/coala-utils.git
 git-url-parse
-django
+django>2.1,<2.2
 django-distill
 django-eventtools
 git+https://gitlab.com/gitmate/open-source/IGitt.git@1fa5a0a21ea4fb8739d467c06972f748717adbdc

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 python-tag = py34.py35.py36
 
 [tool:pytest]
-minversion = 3.6.1
+minversion = 3.6.4
 
 DJANGO_SETTINGS_MODULE = community.settings
 
@@ -111,4 +111,8 @@ exclude_lines =
   def clear_score
   def __str__
 
+partial_branches =
+  pragma: no ?branch
+  pragma.* ${PLATFORM_SYSTEM}: no branch
+  pragma.* ${OS_NAME}: no branch
 [coverage:force_end_of_section]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,7 +12,7 @@ coverage-config-reload-plugin~=0.2
 codecov~=2.0.5
 moban~=0.3.3 ; python_version > '3.0'
 packaging~=16.8
-pytest~=3.6.1
+pytest~=3.6.4
 pytest-cov~=2.4
 pytest-django~=3.3.3
 pytest-env~=0.6.0
@@ -24,7 +24,6 @@ pytest-reorder~=0.1.0
 git+https://github.com/jayvdb/pytest-reqs@coala#egg=pytest-reqs
 pytest-timeout~=1.3.0
 pytest-travis-fold~=1.3.0
-pytest-xdist~=1.15
 requests-mock~=1.2
 ipdb~=0.11
 pip<10


### PR DESCRIPTION
The CI builds were failing due to un-synced moban &
latest versions installed of Django and pytest-xdist.
The django v2.1.8 or later version doesn't support
sqlite v3.8.2 anymore which is a pre-installed package
in Ubuntu Trusty. And, latest pytest-xdist needs
pytest v4.4.0 but v3.6.4 is being installed.

Closes https://github.com/coala/community/issues/243
Closes https://github.com/coala/community/issues/241, https://github.com/coala/community/pull/246